### PR TITLE
T184567 - Remove $registration validation on User constructor

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -67,9 +67,6 @@ class User {
 		if( !is_int( $editcount ) ) {
 			throw new InvalidArgumentException( '$editcount must be an int' );
 		}
-		if( !is_string( $registration ) ) {
-			throw new InvalidArgumentException( '$registration must be a string' );
-		}
 		if( !is_array( $groups ) || !array_key_exists( 'groups', $groups ) || !array_key_exists( 'implicitgroups', $groups ) ) {
 			throw new InvalidArgumentException( '$groups must be an array or arrays with keys "groups" and "implicitgroups"' );
 		}
@@ -139,6 +136,5 @@ class User {
 	public function getRights() {
 		return $this->rights;
 	}
-
 
 } 

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -30,6 +30,7 @@ class UserTest extends \PHPUnit_Framework_TestCase {
 			array( 'Username', 1, 1, 'TIMESTAMP', array( 'groups' => array(), 'implicitgroups' => array() ), array(), 'male' ),
 			array( 'Username', 1, 1, 'TIMESTAMP', array( 'groups' => array(), 'implicitgroups' => array() ), array(), 'female' ),
 			array( 'Username', 99999999, 99999997, 'TIMESTAMP', array( 'groups' => array(), 'implicitgroups' => array() ), array(), 'male' ),
+			array( 'Username', 1, 1, null, array( 'groups' => array(), 'implicitgroups' => array() ), array(), 'female' ),
 		);
 	}
 

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -46,7 +46,6 @@ class UserTest extends \PHPUnit_Framework_TestCase {
 			array( 'Username', 1, 1, 'TIMESTAMP', 'bad', array(), 'male' ),
 			array( 'Username', 1, 1, 'TIMESTAMP', array( 'groups' => array(), 'implicitgroups' => array() ), 'bad', 'male' ),
 			array( 'Username', 1, 1, 'TIMESTAMP', array( 'groups' => array(), 'implicitgroups' => array() ), array(), 1 ),
-			array( 'Username', 1, 1, 219279148412, array( 'groups' => array(), 'implicitgroups' => array() ), array(), 'male' ),
 			array( 'Username', 1, 'bad', 'TIMESTAMP', array( 'groups' => array(), 'implicitgroups' => array() ), array(), 'male' ),
 			array( 'Username', 'bad', 1, 'TIMESTAMP', array( 'groups' => array(), 'implicitgroups' => array() ), array(), 'male' ),
 			array( 14287941, 1, 1, 'TIMESTAMP', array( 'groups' => array(), 'implicitgroups' => array() ), array(), 'male' ),


### PR DESCRIPTION
Some users have the registration field empty and the user
constructor fails on those cases