### PR TITLE
Update jsonSerialize method signature in PageIdentifier.

### DIFF
--- a/src/PageIdentifier.php
+++ b/src/PageIdentifier.php
@@ -39,7 +39,7 @@ class PageIdentifier implements JsonSerializable {
 	 * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
 	 * @return array <string mixed>
 	 */
-	public function jsonSerialize() {
+	public function jsonSerialize(): array {
 		$array = [];
 		if ( $this->id !== null ) {
 			$array['id'] = $this->id;


### PR DESCRIPTION
### Purpose:
Improve type safety and code clarity by explicitly declaring the array return type for the `jsonSerialize` method, which implements the `JsonSerializable` interface.

### Changes:
- Modified `jsonSerialize` method in `src/PageIdentifier.php` to explicitly return `array`.